### PR TITLE
update TargetFramework version to 9.0 and PackageReference version 

### DIFF
--- a/src/Generator.csproj
+++ b/src/Generator.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="Knapcode.TorSharp" Version="2.12.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Knapcode.TorSharp" Version="2.15.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Generator.csproj
+++ b/src/Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Knapcode.TorSharp" Version="2.15.0" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Do ``.NET 7`` không còn được hỗ trợ nữa (không còn cài đặt được thông qua package manager) nên chuyển sang ``.NET 9``, sẵn tiện cập nhật các package lên phiên bản mới nhất luôn.
(đã chạy thử)