### PR TITLE
QOL: Giảm kích cỡ thư mục hvcache bằng cách chỉ giữ lại các class cần thiết

### DIFF
--- a/src/Converters/HanNomConverter.cs
+++ b/src/Converters/HanNomConverter.cs
@@ -223,7 +223,9 @@ public class HanNomConverter : ConverterBase
                         }
 
                         // Save the valid html for reuse and/or debugging purposes.
-                        await File.WriteAllTextAsync(cacheFile, document.DocumentNode.OuterHtml);
+                        // await File.WriteAllTextAsync(cacheFile, document.DocumentNode.OuterHtml);
+                        // Save the truncated html to save space
+                        await File.WriteAllTextAsync(cacheFile, HvresDocument.TruncateHtml(document.DocumentNode));
                     }
 
                     // Strip every goddamn thing except the kanji.

--- a/src/Generator.csproj
+++ b/src/Generator.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="Knapcode.TorSharp" Version="2.12.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Knapcode.TorSharp" Version="2.15.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Generator.csproj
+++ b/src/Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Knapcode.TorSharp" Version="2.15.0" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/HanViet/HvresDocument.cs
+++ b/src/HanViet/HvresDocument.cs
@@ -1,5 +1,4 @@
 ﻿using HtmlAgilityPack;
-using System.Reflection.Metadata;
 
 namespace Generator.HanViet;
 
@@ -30,5 +29,18 @@ public class HvresDocument
         return node.Descendants()
             .Where(x => x.HasClass("hvres-details"))
             .Any();
+    }
+    public static string TruncateHtml(HtmlNode node)
+    {
+        var bases = node.Descendants()
+        .Where(n => n.HasClass("hvres") && (n.HasClass("han-word") || !string.IsNullOrEmpty(n.Attributes["name"]?.Value)))
+        .ToList();
+        using var writer = new StringWriter();
+        foreach (var item in bases)
+        {
+            item.WriteTo(writer);
+            writer.WriteLine();
+        }
+        return writer.ToString();
     }
 }


### PR DESCRIPTION
Kích cỡ của thư mục ``hvcache`` hơi cao bởi vì chương trình lưu mấy tập tin HTML gốc (giữ thẻ ``head`` các thứ), nhưng mà chương trình chỉ cần lưu mấy lớp có ``hvres`` thôi, nên mình thử thay vì lưu tất cả thì chỉ lưu các nodes cần thiết.

Kích cỡ cache giảm gần một nửa. Đầu ra gần như không đổi.
<img width="746" height="179" alt="Screenshot_20251222_173423" src="https://github.com/user-attachments/assets/b6c3a9b3-a31d-404f-9001-cd3b06bb6e26" />
Đầu ra kiểm tra thì có sự khác biệt nhưng mà mình nhìn thử thì hình như chỉ khác biệt về vị trí mấy cái định nghĩa.

<img width="1579" height="54" alt="Screenshot 2025-12-22 at 17-33-23 亜 a á á t  ↔ 亜 a á á th  - Diffchecker" src="https://github.com/user-attachments/assets/f2116ad1-73d4-4137-8842-474e304246be" />

Phần code hơi cơ bản, nếu có cách khác nhanh hơn và tốt hơn thì có thể thay đổi.

Chương trình tuy mục đích là chỉ chạy một lần nhưng mà mình nghĩ giảm kích cỡ cache cũng tốt, do lúc tải về thì cũng phải tải luôn cache. Mình chỉ cập nhật phần code liên quan chứ không cập nhật thư mục cache mới do số lượng tập tin lớn. <br>

Thứ tự commit hơi lộn xộn do mình quên sync branch trước khi commit. 